### PR TITLE
rpi-secure: remove poky

### DIFF
--- a/conf/distro/rpi-secure.conf
+++ b/conf/distro/rpi-secure.conf
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2026 Embetrix Embedded Systems Solutions <ayoub.zaki@embetrix.com>
 
-require conf/distro/poky.conf
-
 DISTRO = "rpi-secure"
 DISTRO_NAME = "rpi-secure"
 


### PR DESCRIPTION
The meta-yocto layer is not listed in dependencies making this `require` create an error. Furthermore, this require adds the scary "Don't use Poky" message banner when logging in, so it's a net detriments. Removing it makes everything fall back to OE-core faults, which also seem to be a better fit, since it uses systemd by default.

Not build tested, currently watching your presentation :)