### PR TITLE
swupdate: provision suricatta (hawkBit) settings per device at runtime

### DIFF
--- a/recipes-core/volatile-binds/volatile-binds%.bbappend
+++ b/recipes-core/volatile-binds/volatile-binds%.bbappend
@@ -9,7 +9,8 @@ VOLATILE_BINDS:append = "\
 ${localstatedir}/data${sysconfdir}/certs            ${sysconfdir}/certs\n\
 ${localstatedir}/data${sysconfdir}/ssh/keys         ${sysconfdir}/ssh/keys\n\
 ${localstatedir}/data${sysconfdir}/systemd/network/ ${sysconfdir}/systemd/network/\n\
-${localstatedir}/data/${sysconfdir}/nginx/.htpasswd ${sysconfdir}/nginx/.htpasswd\n\
+${localstatedir}/data${sysconfdir}/nginx/.htpasswd ${sysconfdir}/nginx/.htpasswd\n\
+${localstatedir}/data${sysconfdir}/swupdate/suricatta.conf ${sysconfdir}/swupdate/suricatta.conf\n\
 ${localstatedir}/data${sysconfdir}/systemd/journal-upload.conf ${sysconfdir}/systemd/journal-upload.conf\n\
 ${localstatedir}/data${localstatedir}/log            ${localstatedir}/log\n\
 ${@bb.utils.contains('MACHINE_FEATURES', 'wifi', '${localstatedir}/data${sysconfdir}/wpa_supplicant ${sysconfdir}/wpa_supplicant\\n', '', d)}\

--- a/recipes-support/swupdate/files/20-suricatta-args
+++ b/recipes-support/swupdate/files/20-suricatta-args
@@ -1,0 +1,20 @@
+# Build the suricatta (hawkBit) arguments for swupdate.sh
+# Sourced by /usr/lib/swupdate/swupdate.sh. Setting SWUPDATE_SURICATTA_ARGS to a
+# non-empty value is what enables suricatta (adds `-u` to the swupdate command)
+#
+# Server url, tenant, device id and gateway token are read from an env file that
+# can be provisioned per device without rebuilding the image. The device id
+# defaults to the hostname.
+
+SURICATTA_ENV="/etc/swupdate/suricatta.conf"
+[ -f "$SURICATTA_ENV" ] && . "$SURICATTA_ENV"
+
+# Device/controller id: env override wins, otherwise use the hostname
+SURICATTA_ID="${SURICATTA_ID:-$(hostname)}"
+
+SWUPDATE_SURICATTA_ARGS="-i ${SURICATTA_ID}"
+
+# Append the remaining options only when provided.
+[ -n "${SURICATTA_URL}" ]            && SWUPDATE_SURICATTA_ARGS="${SWUPDATE_SURICATTA_ARGS} -u ${SURICATTA_URL}"
+[ -n "${SURICATTA_TENANT}" ]         && SWUPDATE_SURICATTA_ARGS="${SWUPDATE_SURICATTA_ARGS} -t ${SURICATTA_TENANT}"
+[ -n "${SURICATTA_GATEWAY_TOKEN}" ]  && SWUPDATE_SURICATTA_ARGS="${SWUPDATE_SURICATTA_ARGS} -g ${SURICATTA_GATEWAY_TOKEN}"

--- a/recipes-support/swupdate/files/suricatta.conf
+++ b/recipes-support/swupdate/files/suricatta.conf
@@ -1,0 +1,14 @@
+# Per-device suricatta (hawkBit) settings:
+
+# hawkBit server URL
+SURICATTA_URL=https://embetrix.works/hawkbit
+
+# hawkBit tenant
+SURICATTA_TENANT=default
+
+# Controller/device id reported to hawkBit
+# Leave unset to default to the device hostname
+#SURICATTA_ID=
+
+# hawkBit gateway security token
+#SURICATTA_GATEWAY_TOKEN=

--- a/recipes-support/swupdate/files/swupdate.cfg
+++ b/recipes-support/swupdate/files/swupdate.cfg
@@ -14,23 +14,17 @@ webserver :
 	groupid			= 4001;
 };
 
-
-/*
 suricatta :
 {
-	tenant			= "default";
-	id				= "__DEVID__";
-	url				= "https://embetrix.works/hawkbit";
 	polldelay		= 20;
 	nocheckcert		= false;
-	sslcert			= "/etc/certs/rpi-device-cert.pem";
-	sslkey			= "pkcs11:token=RPi%20OTP%20key;id=%01;type=private";
+	/*sslcert			= "/etc/certs/rpi-device-cert.pem";*/
+	/*sslkey			= "pkcs11:token=RPi%20OTP%20key;id=%01;type=private";*/
 	retry			= 4;
 	retrywait		= 200;
 	loglevel		= 10;
 	enable			= true;
 	userid			= 4002;
 	groupid			= 4002;
-	gatewaytoken = "xxxxxxxxx";
 }
-*/
+

--- a/recipes-support/swupdate/swupdate_%.bbappend
+++ b/recipes-support/swupdate/swupdate_%.bbappend
@@ -5,6 +5,8 @@ SRC_URI:append = " \
      file://0002-channel_curl-fix-wrong-evaluation-for-pkcs11-sslcert.patch \
      file://0003-channel_curl-support-OpenSSL-provider-for-PKCS-11-UR.patch \
      file://swupdate.cfg \
+     file://suricatta.conf \
+     file://20-suricatta-args \
      file://sw-versions \
      file://background.jpg \
      file://index.html \
@@ -25,6 +27,14 @@ do_install:append() {
 
     install -d ${D}${sysconfdir}/swupdate
     install -m 644 ${UNPACKDIR}/swupdate.cfg ${D}${sysconfdir}/swupdate/swupdate.cfg
+
+    # Per-device suricatta (hawkBit) settings: device id (defaults to hostname)
+    # and gateway token, provisionable at runtime without rebuilding the image.
+    install -m 600 ${UNPACKDIR}/suricatta.conf ${D}${sysconfdir}/swupdate/suricatta.conf
+
+    # conf.d snippet sourced by swupdate.sh to build the suricatta args
+    install -d ${D}${libdir}/swupdate/conf.d
+    install -m 644 ${UNPACKDIR}/20-suricatta-args ${D}${libdir}/swupdate/conf.d/20-suricatta-args
 
     # Certificates are added if configured with artifacts signing
     if [ "${SWUPDATE_SIGNING}" = "CMS" ] && [ -f "${SWUPDATE_CMS_CERT}" ]; then
@@ -70,6 +80,8 @@ do_install:append() {
 FILES:${PN} += "${sysconfdir}/swupdate \
                 ${sysconfdir}/sw-versions \
                 ${sysconfdir}/hwrevision"
+
+CONFFILES:${PN} += "${sysconfdir}/swupdate/suricatta.conf"
 
 # Verify a pending A/B update after boot (timer-triggered): 
 # confirm the slot if healthy, rollback otherwise


### PR DESCRIPTION
Move the suricatta connection settings out of the compiled swupdate.cfg into a runtime env file so device id, url, tenant and gateway token can be provisioned:

- swupdate.cfg: enable the suricatta block and keep only static options (polldelay, retry, loglevel, ids, enable) drop the hardcoded id, url, tenant, gatewaytoken and the pkcs11 sslcert/sslkey
- Add suricatta.conf env file (SURICATTA_URL/TENANT/ID/GATEWAY_TOKEN), installed as a CONFFILE make id defaults to the hostname.
- Add conf.d/20-suricatta-args, sourced by swupdate.sh, to build SWUPDATE_SURICATTA_ARGS from the env file (-i/-u/-t/-g)
- volatile-binds: bind-mount /etc/swupdate/suricatta.conf onto the encrypted data partition so the settings persist